### PR TITLE
Handling different HTTP Responses, Adding MLH Code of Conduct

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -15,10 +15,10 @@ export default class Footer extends Component {
 
   render() {
     return (
-      <footer className="bar-wrapper footer">
-        <p id="footer-madewithlove">Made with <FontAwesomeIcon icon={faHeart} size='sm'/> by the <span id="footer-purple">cu</span>Hacking team</p> 
-        <p id="footer-questions">Questions? Send us an email at <a className="mailtoLink" href="mailto:info@cuhacking.com"> info@cuhacking.com </a> </p>
-        <SocialLinks/>
+      <footer className="bar-wrapper footer">        
+          <SocialLinks/>
+          <p> Made with <FontAwesomeIcon icon={faHeart} size='sm'/> by the <span id="footer-purple">cu</span>Hacking team</p> 
+          <p><a  target="onblank" rel="noopener noreferrer" id="MLHCodeOfConduct" href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf"> MLH Code of Conduct </a></p> 
       </footer>
     )
   }

--- a/src/components/mailingListForm.css
+++ b/src/components/mailingListForm.css
@@ -73,7 +73,8 @@
 }
 
 .errorMessage {
-  font-family: Inconsolata; 
+  text-align: center; 
+  font-family: 'Montserrat', sans-serif;
   color: red; 
 }
 

--- a/src/components/mailingListForm.css
+++ b/src/components/mailingListForm.css
@@ -73,7 +73,7 @@
 }
 
 .errorMessage {
-  text-align: center; 
+  text-align: right; 
   font-family: 'Montserrat', sans-serif;
   color: red; 
 }
@@ -83,6 +83,10 @@
 }
 
 @media (orientation: portrait) {
+  .errorMessage {
+    text-align: center; 
+  }
+  
   .dialogText {
     text-align: center;
   }

--- a/src/components/mailingListForm.js
+++ b/src/components/mailingListForm.js
@@ -54,7 +54,6 @@ export default class MailingListForm extends Component {
         fetch(API_URL, options)
             .then(res => {
                 res.json()
-                console.log(res)
                 if(res.status === 201) {
                     // The email was added successfully. 
                     this.setState({status: 'after'}); 

--- a/src/components/mailingListForm.js
+++ b/src/components/mailingListForm.js
@@ -52,8 +52,9 @@ export default class MailingListForm extends Component {
         }; 
 
         fetch(API_URL, options)
-            .then(res => res.json())
             .then(res => {
+                res.json()
+                console.log(res)
                 if(res.status === 201) {
                     // The email was added successfully. 
                     this.setState({status: 'after'}); 

--- a/src/components/mailingListForm.js
+++ b/src/components/mailingListForm.js
@@ -52,13 +52,18 @@ export default class MailingListForm extends Component {
         }; 
 
         fetch(API_URL, options)
-            .then(res => res.json())    
+            .then(res => res.json())
             .then(res => {
-                console.log(res)
-                if(res.status === "success") {
+                if(res.status === 201) {
+                    // The email was added successfully. 
                     this.setState({status: 'after'}); 
+                } else if (res.status === 400) {
+                    // Server said the email was invalid. 
+                    this.setState({error: 'That email didn\'t look right! Try again?', loading: false, status: 'before'}); 
+                } else if (res.status === 500) {
+                    this.setState({error: 'Something went wrong on our end! Try it again!', loading: false, status: 'before'});
                 } else {
-                    this.setState({loading: false, status: 'before'}); 
+                    this.setState({error: 'Uh-oh! That didn\'t work. Try again?', value: '', valid: false, loading: false}); 
                 }
             })
             .catch(err => {
@@ -73,18 +78,6 @@ export default class MailingListForm extends Component {
     }
 
     render() {
-        /*
-        return (
-            <div id="mailingListForm" onClick={this.openField}>
-                {this.text()}
-                <form className={`emailForm ${this.state.status}`} onSubmit={this.handleSubmit}>
-                    <input className="emailField"     disabled={this.state.loading || this.state.status === "after"} type="text" placeholder="Enter your email address.." value={this.state.value} onChange={this.handleChange} />
-                    <button className="submitButton"  disabled={this.state.loading || this.state.status === "after" || !this.state.valid} type="submit"> <FontAwesomeIcon icon={faArrowRight}/></button>
-                </form>
-            </div>
-        );  
-        */
-
        return (
         <div id="mailingListForm" onClick={this.openField}>
             {this.text()}
@@ -92,6 +85,7 @@ export default class MailingListForm extends Component {
                 <input className="emailField"     disabled={this.state.loading || this.state.status === "after"} type="text" placeholder="Enter your email address.." value={this.state.value} onChange={this.handleChange} />
                 <button className="submitButton"  disabled={this.state.loading || this.state.status === "after" || !this.state.valid} type="submit"> <FontAwesomeIcon icon={faArrowRight}/></button>
             </form>
+            <p className="errorMessage">&nbsp;{this.state.error}</p>
         </div>
     );  
     } 

--- a/src/components/partners.js
+++ b/src/components/partners.js
@@ -40,6 +40,7 @@ export default class Partners extends Component {
                 <Partner id="SCELogo" url="https://carleton.ca/sce/" src={logoSCE} alt="Link to Carleton's School of Computer and Systems Engineering Webpage"/>
                 <Partner id="MLHLogo" url="https://mlh.io/"          src={logoMLH} alt="Link to MLH Webpage"/>
             </div>
+            <p id="footer-questions">Questions? Send us an email at <a className="mailtoLink" href="mailto:info@cuhacking.com"> info@cuhacking.com </a> </p>
         </div> 
     )
   }

--- a/src/components/socialLinks.js
+++ b/src/components/socialLinks.js
@@ -14,7 +14,7 @@ export default class SocialLinks extends Component {
   createLogo(icon, target, link) {
     return (
       <a className={styles.socialButton} target={target} rel='noopener noreferrer' href={link}>
-        <FontAwesomeIcon icon={icon} size='lg'/>
+        <FontAwesomeIcon icon={icon} size='1x'/>
       </a> 
     );
   }

--- a/src/index.css
+++ b/src/index.css
@@ -191,7 +191,7 @@ input:focus {
   font-family: 'Reem Kufi', sans-serif;
   display: flex; 
   flex-direction: row; 
-  justify-content: space-around;
+  justify-content: space-evenly;
   align-items: center; 
   height: 100px; 
   width: 100vw; 
@@ -220,6 +220,15 @@ input:focus {
 
 #footer-purple { 
   color: #9756D8; 
+}
+
+#MLHCodeOfConduct  {
+  color: white;  
+  transition-duration: 0.3s;
+}
+
+#MLHCodeOfConduct:hover  {
+  color: #7C39BF; 
 }
 
 .mailtoLink {
@@ -285,15 +294,11 @@ input:focus {
   width: 100px; 
 }
 
-#sponsor-ciena {
-  width: 250px;
-}
-
-#sponsor-lighthouse {
-  width: 310px; 
-}
-
 /* Partners */ 
+.partners {
+  margin-bottom: 100px; 
+}
+
 .partner-wrapper {
   display: flex;
   flex-direction: row; 


### PR DESCRIPTION
Prior to this PR, mailinglistform.js checks for 'success' but does not respond to 201, 400, 500 codes. This adds error messages for 400 and 500, and responds appropriately for a successful email sign up. (https://trello.com/c/6N7iGODD/181-handle-different-http-responses) 

Also adds a link to the MLH code of conduct on the footer (https://trello.com/c/guJCFb45/187-add-mlh-code-of-conduct-to-the-website)