### PR TITLE
Prefers-color-scheme Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cuhacking-website",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "homepage": "https://cuhacking.com",
   "dependencies": {

--- a/src/components/navbar.module.css
+++ b/src/components/navbar.module.css
@@ -1,12 +1,5 @@
-@media (prefers-color-scheme: light) {
-  * {
-    --navLogo: url('../assets/shortLogo.svg');
-  }
-}
-@media (prefers-color-scheme: dark) {
-  * {
-    --navLogo: url('../assets/shortLogo-dark.svg');
-  }
+* {
+  --navLogo: url('../assets/shortLogo.svg');
 }
 
 #container {
@@ -41,5 +34,11 @@
 @media only screen and (min-width: 700px) {
   #navbar {
     justify-content: flex-start;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  * {
+    --navLogo: url('../assets/shortLogo-dark.svg');
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,27 +1,12 @@
-@media (prefers-color-scheme: light) {
-  * {
-    --textColour: #000000;
-    --secondTextColour: #FFFFFF; 
-    --lightPrimaryColour: #9756D8; 
-    --primaryColour: #5827B8;
-    --darkPrimaryColour: #280749;
-    --secondaryColour: #00D0FE;
-    --background: url('./assets/bkg.svg');
-    --backgroundColour: white; 
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  * {
-    --textColour: #ffffff;
-    --secondTextColour: #FFFFFF; 
-    --lightPrimaryColour: #9756D8; 
-    --primaryColour: #5827B8;
-    --darkPrimaryColour: #280749;
-    --secondaryColour: #00D0FE;
-    --background: url('./assets/bkg-dark.svg'); 
-    --backgroundColour: black; 
-  }
+* {
+  --textColour: #000000;
+  --secondTextColour: #FFFFFF; 
+  --lightPrimaryColour: #9756D8; 
+  --primaryColour: #5827B8;
+  --darkPrimaryColour: #280749;
+  --secondaryColour: #00D0FE;
+  --background: url('./assets/bkg.svg');
+  --backgroundColour: white; 
 }
 
 a {
@@ -62,4 +47,17 @@ h2 {
   background-size: cover;
   background-position: bottom;
   min-height: 100vh;
+}
+
+@media (prefers-color-scheme: dark) {
+  * {
+    --textColour: #ffffff;
+    --secondTextColour: #FFFFFF; 
+    --lightPrimaryColour: #9756D8; 
+    --primaryColour: #5827B8;
+    --darkPrimaryColour: #280749;
+    --secondaryColour: #00D0FE;
+    --background: url('./assets/bkg-dark.svg'); 
+    --backgroundColour: black; 
+  }
 }

--- a/src/pages/home/index.module.css
+++ b/src/pages/home/index.module.css
@@ -1,12 +1,5 @@
-@media (prefers-color-scheme: light) {
-  * {
-    --dateSvg: url('../../assets/dateStamp.svg');
-  }
-}
-@media (prefers-color-scheme: dark) {
-  * {
-    --dateSvg: url('../../assets/dateStamp-dark.svg');
-  }
+* {
+  --dateSvg: url('../../assets/dateStamp.svg');
 }
 
 #content {
@@ -244,5 +237,11 @@
   
   #partners {
     flex-direction: row;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  * {
+    --dateSvg: url('../../assets/dateStamp-dark.svg');
   }
 }


### PR DESCRIPTION
We had an issue where on some browsers, many elements wouldn't appear.
This was because when we used prefers-color-scheme, we were checking for
both light and dark themes specifically. If a device didn't support it,
then neither would be chosen.

The solution was to only use prefers-color-scheme when checking for a
dark theme, and providing the light theme as default.