### PR TITLE
Hotfix: Correct the Password Reset API URL

### DIFF
--- a/src/pages/forgot/index.js
+++ b/src/pages/forgot/index.js
@@ -46,7 +46,7 @@ class Forgot extends React.Component {
       }
     }; 
 
-    fetch("https://cuhacking.com/api-dev/resetpassword", options)
+    fetch("https://cuhacking.com/api-dev/users/resetpassword", options)
       .then(res => {
           res.json()
           if(res.status === 200) {


### PR DESCRIPTION
It was incorrectly calling to .../api-dev/resetpassword. 
Change it to /api-dev/users/resetpassword so it matches the documentation.