### PR TITLE
Hotfix: Fix duplicate names for School Fields

### DIFF
--- a/src/pages/application/index.js
+++ b/src/pages/application/index.js
@@ -180,7 +180,7 @@ const AboutYou = ({initialState, nextPage}) => {
       <form onSubmit={onSubmit} onChange={onChange} className={styles.formContainer}>
         <div className={styles.section}>
           <Input defaultValue={personalInfo.school} name="school" type="text" label="What school do you attend? *" required={true} inputStyle='select' options={['', ...schools]}/>
-          <Input defaultValue={personalInfo.otherSchool} name='school' type="text" label="If other, please specify." />
+          <Input defaultValue={personalInfo.otherSchool} name='otherSchool' type="text" label="If other, please specify." />
         </div>
         <div className={styles.section}>
           <Input placeholder='Computer Science' defaultValue={personalInfo.major} name="major" type="text" label="What is your major?*" required={true}/>


### PR DESCRIPTION
The school and other school fields use the same name 'school'. So if somebody chose 'Other' as their school, and typed in a school in the text box for _other school_ than it would save the value in _other school_. The issue is that if somebody selects a school like 'Carleton University' and has any text entered (even a blank space) in the 'other school' field - than it will record the text in the 'other school' field. 